### PR TITLE
Prevent adding a state which name is already persistent

### DIFF
--- a/Code/TKStateMachine.m
+++ b/Code/TKStateMachine.m
@@ -110,6 +110,8 @@ static NSString *TKQuoteString(NSString *string)
 {
     TKRaiseIfActive();
     if (! [state isKindOfClass:[TKState class]]) [NSException raise:NSInvalidArgumentException format:@"Expected a `TKState` object, instead got a `%@` (%@)", [state class], state];
+    if ([self stateNamed: state.name]) [NSException raise:NSInvalidArgumentException format:@"State with name `%@` already exists", state.name];
+
     if (self.initialState == nil) self.initialState = state;
     [self.mutableStates addObject:state];
 }

--- a/Specs/TKStateMachineSpec.m
+++ b/Specs/TKStateMachineSpec.m
@@ -69,6 +69,17 @@ context(@"when initialized", ^{
             [stateMachine addState:state];
         });
         
+
+        context(@"which name is already present", ^{
+            it(@"raises an exception", ^{
+                TKState *singleState = [TKState stateWithName:@"Single"];
+
+                [[theBlock(^{
+                    [stateMachine addState:singleState];
+                }) should] raiseWithName:NSInvalidArgumentException reason:@"State with name `Single` already exists"];
+            });
+        });
+
         it(@"has a state count of 1", ^{
             [[stateMachine.states should] haveCountOf:1];
         });
@@ -182,7 +193,6 @@ describe(@"setting the initial state", ^{
     
     context(@"when the state machine has not been started", ^{
         beforeEach(^{
-            [stateMachine addState:[TKState stateWithName:@"Dating"]];
             stateMachine.initialState = [stateMachine stateNamed:@"Dating"];
         });
         
@@ -218,7 +228,7 @@ describe(@"addState:", ^{
         it(@"raises an NSInvalidArgumentException", ^{
             [[theBlock(^{
                 [stateMachine addState:(TKState *)@1234];
-            }) should] raiseWithName:NSInvalidArgumentException reason:@"Expected a `TKState` object or `NSString` object specifying the name of a state, instead got a `__NSCFNumber` (1234)"];
+            }) should] raiseWithName:NSInvalidArgumentException reason:@"Expected a `TKState` object, instead got a `__NSCFNumber` (1234)"];
         });
     });
 });


### PR DESCRIPTION
Also keen on adding `addStateWithName:`, would you like me to add it?

I've implemented the method in a category, looking like this:

``` objc
-(TKState*) addStateWithName:(NSString *)name
{
    if (! [name isKindOfClass:[NSString class]]) [NSException raise:NSInvalidArgumentException format:@"Expected a `NSString` object, instead got a `%@` (%@)", [name class], name];

    TKState *state = [TKState stateWithName:name];

    [self addState:state];

    return state;
}
```
