### PR TITLE
canFireEvent: returns false if event.sourceStates is nil

### DIFF
--- a/Code/TKStateMachine.m
+++ b/Code/TKStateMachine.m
@@ -196,7 +196,7 @@ static NSString *TKQuoteString(NSString *string)
     if (! [eventOrEventName isKindOfClass:[TKEvent class]] && ![eventOrEventName isKindOfClass:[NSString class]]) [NSException raise:NSInvalidArgumentException format:@"Expected a `TKEvent` object or `NSString` object specifying the name of an event, instead got a `%@` (%@)", [eventOrEventName class], eventOrEventName];
     TKEvent *event = [eventOrEventName isKindOfClass:[TKEvent class]] ? eventOrEventName : [self eventNamed:eventOrEventName];
     if (! event) [NSException raise:NSInvalidArgumentException format:@"Cannot find an Event named '%@'", eventOrEventName];
-    return [event.sourceStates containsObject:self.currentState];
+    return event.sourceStates == nil || [event.sourceStates containsObject:self.currentState];
 }
 
 - (BOOL)fireEvent:(id)eventOrEventName userInfo:(NSDictionary *)userInfo error:(NSError *__autoreleasing *)error


### PR DESCRIPTION
Currently, - [TKStateMachine canFireEvent] only checks whether event.sourceStates contains the state machine's currentState.  However, the event will also fire if event.sourceStates is nil.  