### PR TITLE
missing Foundation import in TKTransition.h

### DIFF
--- a/Code/TKTransition.h
+++ b/Code/TKTransition.h
@@ -18,6 +18,8 @@
 //  limitations under the License.
 //
 
+#import <Foundation/Foundation.h>
+
 @class TKEvent, TKState, TKStateMachine;
 
 /**


### PR DESCRIPTION
will cause compiler errors in Swift projects
