### PR TITLE
Add a `dotDescription` property to TKStateMachine

### DIFF
--- a/Code/TKStateMachine.h
+++ b/Code/TKStateMachine.h
@@ -200,6 +200,17 @@
  */
 - (BOOL)fireEvent:(id)eventOrEventName userInfo:(NSDictionary *)userInfo error:(NSError **)error;
 
+///------------------
+/// @name Description
+///------------------
+
+/**
+ A description of the state machine in the DOT graph description language.
+ 
+ @see http://en.wikipedia.org/wiki/DOT_(graph_description_language)
+ */
+@property (readonly) NSString *dotDescription;
+
 @end
 
 ///----------------

--- a/Code/TKStateMachine.m
+++ b/Code/TKStateMachine.m
@@ -91,13 +91,6 @@ static NSString *TKQuoteString(NSString *string)
     return self;
 }
 
-- (NSString *)description
-{
-    return [NSString stringWithFormat:@"<%@:%p %ld States, %ld Events. currentState=%@, initialState='%@', isActive=%@>",
-            NSStringFromClass([self class]), self, (unsigned long) [self.mutableStates count], (unsigned long) [self.mutableEvents count],
-            TKQuoteString(self.currentState.name), self.initialState.name, self.isActive ? @"YES" : @"NO"];
-}
-
 - (void)setInitialState:(TKState *)initialState
 {
     TKRaiseIfActive();
@@ -305,6 +298,33 @@ static NSString *TKQuoteString(NSString *string)
         [copiedStateMachine addEvent:copiedEvent];
     }
     return copiedStateMachine;
+}
+
+#pragma mark - Description
+
+- (NSString *)description
+{
+    return [NSString stringWithFormat:@"<%@:%p %ld States, %ld Events. currentState=%@, initialState='%@', isActive=%@>",
+            NSStringFromClass([self class]), self, (unsigned long) [self.mutableStates count], (unsigned long) [self.mutableEvents count],
+            TKQuoteString(self.currentState.name), self.initialState.name, self.isActive ? @"YES" : @"NO"];
+}
+
+- (NSString *)dotDescription
+{
+    NSMutableString *dotDescription = [[NSMutableString alloc] initWithString:@"digraph StateMachine {\n"];
+    if (self.initialState) {
+        [dotDescription appendFormat:@"  \"\" [style=\"invis\"]; \"\" -> \"%@\" [dir=both, arrowtail=dot]; // Initial State\n", self.initialState.name];
+    }
+    if (self.currentState) {
+        [dotDescription appendFormat:@"  \"%@\" [style=bold]; // Current State\n", self.currentState.name];
+    }
+    for (TKEvent *event in self.events) {
+        for (TKState *sourceState in event.sourceStates) {
+            [dotDescription appendFormat:@"  \"%@\" -> \"%@\" [label=\"%@\", fontname=\"Menlo Italic\", fontsize=9];\n", sourceState.name, event.destinationState.name, event.name];
+        }
+    }
+    [dotDescription appendString:@"}"];
+    return [dotDescription copy];
 }
 
 @end


### PR DESCRIPTION
This can greatly improve understanding what a state machine looks like.

Here is the visualization of the relationship state machine of the spec:
![statemachine](https://cloud.githubusercontent.com/assets/51363/6641097/0f4c8564-c99c-11e4-9d47-b6079b23dce4.png)
