### PR TITLE
Improved notifications

### DIFF
--- a/Code/TKStateMachine.h
+++ b/Code/TKStateMachine.h
@@ -219,17 +219,17 @@ extern NSString *const TKStateMachineDidChangeStateNotification;
 /**
  A key in the `userInfo` dictionary of a `TKStateMachineDidChangeStateNotification` notification specifying the state of the machine before the transition occured.
  */
-extern NSString *const TKStateMachineDidChangeStateOldStateUserInfoKey;
+extern NSString *const TKStateMachineDidChangeStateOldStateUserInfoKey DEPRECATED_MSG_ATTRIBUTE("Use TKStateMachineDidChangeStateTransitionUserInfoKey instead (transition.sourceState).");
 
 /**
  A key in the `userInfo` dictionary of a `TKStateMachineDidChangeStateNotification` notification specifying the state of the machine after the transition occured.
  */
-extern NSString *const TKStateMachineDidChangeStateNewStateUserInfoKey;
+extern NSString *const TKStateMachineDidChangeStateNewStateUserInfoKey DEPRECATED_MSG_ATTRIBUTE("Use TKStateMachineDidChangeStateTransitionUserInfoKey instead (transition.destinationState).");
 
 /**
  A key in the `userInfo` dictionary of a `TKStateMachineDidChangeStateNotification` notification specifying the event that triggered the transition between states.
  */
-extern NSString *const TKStateMachineDidChangeStateEventUserInfoKey;
+extern NSString *const TKStateMachineDidChangeStateEventUserInfoKey DEPRECATED_MSG_ATTRIBUTE("Use TKStateMachineDidChangeStateTransitionUserInfoKey instead (transition.event).");
 
 /**
  A key in the `userInfo` dictionary of a `TKStateMachineDidChangeStateNotification` notification specifying the transition (TKTransition) between states.

--- a/Code/TKStateMachine.h
+++ b/Code/TKStateMachine.h
@@ -232,6 +232,11 @@ extern NSString *const TKStateMachineDidChangeStateNewStateUserInfoKey;
 extern NSString *const TKStateMachineDidChangeStateEventUserInfoKey;
 
 /**
+ A key in the `userInfo` dictionary of a `TKStateMachineDidChangeStateNotification` notification specifying the transition (TKTransition) between states.
+ */
+extern NSString *const TKStateMachineDidChangeStateTransitionUserInfoKey;
+
+/**
  An exception raised when an attempt is made to mutate an immutable `TKStateMachine` object.
  */
 extern NSString *const TKStateMachineIsImmutableException;

--- a/Code/TKStateMachine.m
+++ b/Code/TKStateMachine.m
@@ -238,9 +238,12 @@ static NSString *TKQuoteString(NSString *string)
     self.currentState = newState;
     
     NSMutableDictionary *notificationInfo = [userInfo mutableCopy] ?: [NSMutableDictionary dictionary];
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
     [notificationInfo addEntriesFromDictionary:@{ TKStateMachineDidChangeStateOldStateUserInfoKey: oldState,
                                                   TKStateMachineDidChangeStateNewStateUserInfoKey: newState,
                                                   TKStateMachineDidChangeStateEventUserInfoKey: event,
+#pragma clang diagnostic pop
                                                   TKStateMachineDidChangeStateTransitionUserInfoKey: transition }];
     [[NSNotificationCenter defaultCenter] postNotificationName:TKStateMachineDidChangeStateNotification object:self userInfo:notificationInfo];
     

--- a/Code/TKStateMachine.m
+++ b/Code/TKStateMachine.m
@@ -41,6 +41,7 @@ NSString *const TKStateMachineDidChangeStateNotification = @"TKStateMachineDidCh
 NSString *const TKStateMachineDidChangeStateOldStateUserInfoKey = @"old";
 NSString *const TKStateMachineDidChangeStateNewStateUserInfoKey = @"new";
 NSString *const TKStateMachineDidChangeStateEventUserInfoKey = @"event";
+NSString *const TKStateMachineDidChangeStateTransitionUserInfoKey = @"transition";
 
 NSString *const TKStateMachineIsImmutableException = @"TKStateMachineIsImmutableException";
 
@@ -239,7 +240,8 @@ static NSString *TKQuoteString(NSString *string)
     NSMutableDictionary *notificationInfo = [userInfo mutableCopy] ?: [NSMutableDictionary dictionary];
     [notificationInfo addEntriesFromDictionary:@{ TKStateMachineDidChangeStateOldStateUserInfoKey: oldState,
                                                   TKStateMachineDidChangeStateNewStateUserInfoKey: newState,
-                                                  TKStateMachineDidChangeStateEventUserInfoKey: event }];
+                                                  TKStateMachineDidChangeStateEventUserInfoKey: event,
+                                                  TKStateMachineDidChangeStateTransitionUserInfoKey: transition }];
     [[NSNotificationCenter defaultCenter] postNotificationName:TKStateMachineDidChangeStateNotification object:self userInfo:notificationInfo];
     
     if (oldState.didExitStateBlock) oldState.didExitStateBlock(oldState, transition);

--- a/Code/TKStateMachine.m
+++ b/Code/TKStateMachine.m
@@ -235,17 +235,18 @@ static NSString *TKQuoteString(NSString *string)
     if (oldState.willExitStateBlock) oldState.willExitStateBlock(oldState, transition);
     if (newState.willEnterStateBlock) newState.willEnterStateBlock(newState, transition);
     self.currentState = newState;
-    if (oldState.didExitStateBlock) oldState.didExitStateBlock(oldState, transition);
-    if (newState.didEnterStateBlock) newState.didEnterStateBlock(newState, transition);
     
-    if (event.didFireEventBlock) event.didFireEventBlock(event, transition);
-    [self.lock unlock];
-
     NSMutableDictionary *notificationInfo = [userInfo mutableCopy] ?: [NSMutableDictionary dictionary];
     [notificationInfo addEntriesFromDictionary:@{ TKStateMachineDidChangeStateOldStateUserInfoKey: oldState,
                                                   TKStateMachineDidChangeStateNewStateUserInfoKey: newState,
                                                   TKStateMachineDidChangeStateEventUserInfoKey: event }];
     [[NSNotificationCenter defaultCenter] postNotificationName:TKStateMachineDidChangeStateNotification object:self userInfo:notificationInfo];
+    
+    if (oldState.didExitStateBlock) oldState.didExitStateBlock(oldState, transition);
+    if (newState.didEnterStateBlock) newState.didEnterStateBlock(newState, transition);
+    
+    if (event.didFireEventBlock) event.didFireEventBlock(event, transition);
+    [self.lock unlock];
     
     return YES;
 }

--- a/Specs/TKStateMachineSpec.m
+++ b/Specs/TKStateMachineSpec.m
@@ -401,10 +401,11 @@ describe(@"A State Machine Modeling Dating", ^{
             [stateMachine fireEvent:@"Start Dating" userInfo:nil error:nil];
             [[expectFutureValue(notification) shouldEventually] beNonNil];
             [[NSNotificationCenter defaultCenter] removeObserver:observer];
-            [notification.userInfo shouldNotBeNil];
-            [[[[notification.userInfo objectForKey:TKStateMachineDidChangeStateOldStateUserInfoKey] name] should] equal:@"Single"];
-            [[[[notification.userInfo objectForKey:TKStateMachineDidChangeStateNewStateUserInfoKey] name] should] equal:@"Dating"];
-            [[[[notification.userInfo objectForKey:TKStateMachineDidChangeStateEventUserInfoKey] name] should] equal:@"Start Dating"];
+            TKTransition *transition = notification.userInfo[TKStateMachineDidChangeStateTransitionUserInfoKey];
+            [transition shouldNotBeNil];
+            [[transition.sourceState.name should] equal:@"Single"];
+            [[transition.destinationState.name should] equal:@"Dating"];
+            [[transition.event.name should] equal:@"Start Dating"];
         });
     });
     


### PR DESCRIPTION
Here are some improvements to `TKStateMachineDidChangeStateNotification`:

1. If a transition is initiated inside a `state.didExitStateBlock`, `state.didEnterStateBlock` or `event.didFireEventBlock` the notifications are posted out of order. By posting right after the state change, the notifications are sent in the expected order.

2. Add a new `TKStateMachineDidChangeStateTransitionUserInfoKey` which provides everything the other user info keys provide, plus the transition’s `userInfo`. Also deprecate all old user info keys.

If you don’t agree with all the changes (but why wouldn’t you anyway? 😉) you should be able to cherry-pick the ones you are interested in.