### PR TITLE
Making sure subclasses of TKState init the right class.

### DIFF
--- a/Code/TKState.m
+++ b/Code/TKState.m
@@ -33,7 +33,7 @@
 + (instancetype)stateWithName:(NSString *)name
 {
     if (! [name length]) [NSException raise:NSInvalidArgumentException format:@"The `name` cannot be blank."];
-    TKState *state = [TKState new];
+    TKState *state = [self new];
     state.name = name;
     return state;
 }


### PR DESCRIPTION
We've subclassed TKState in our project and needed the factory method to create the subclass type.
