### PR TITLE
[BUMP] Version number. IMPORTANT: Using cocoapods 0.39 instead of 0.37.2

### DIFF
--- a/Podfile.lock
+++ b/Podfile.lock
@@ -1,6 +1,6 @@
 PODS:
   - Kiwi (2.3.1)
-  - TransitionKit (2.2.1)
+  - TransitionKit (2.2.2)
 
 DEPENDENCIES:
   - Kiwi (~> 2.3.0)
@@ -12,6 +12,6 @@ EXTERNAL SOURCES:
 
 SPEC CHECKSUMS:
   Kiwi: f038a6c61f7a9e4d7766bff5717aa3b3fdb75f55
-  TransitionKit: 9ceccda4cd0cdc0a05ef85eb235e5a3292c3c250
+  TransitionKit: 3b5cc50528284f0b9775e74baf00cc2cbf7c1565
 
-COCOAPODS: 0.37.2
+COCOAPODS: 0.39.0

--- a/TransitionKit.podspec
+++ b/TransitionKit.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name     = 'TransitionKit'
-  s.version  = '2.2.1'
+  s.version  = '2.2.2'
   s.license  = 'Apache2'
   s.summary  = 'A block-based State Machine API for Objective-C.'
   s.homepage = 'https://github.com/blakewatters/TransitionKit'


### PR DESCRIPTION
# Overview

This PR addresses the changes suggested in this [issue](https://github.com/blakewatters/TransitionKit/issues/32) to release a new version of the pod that included the latest commits.

In particular this PR bumps the existing version to `2.2.2`.
# Testing

The cocoapods version used was `0.39.0` as opposed to `0.37.2` used in the previous version (2.2.1)
